### PR TITLE
Refactor model initialization to prevent unintended pretrained ViT weights during inference

### DIFF
--- a/domains/mri/model.py
+++ b/domains/mri/model.py
@@ -4,9 +4,9 @@ import torch.nn.functional as F
 from models.vit import ViTClassifier
 
 class AlzheimerMRIModel:
-    def __init__(self, num_classes=4, device=None):
+    def __init__(self, num_classes=None, device=None, weights=None):
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
-        self.model = ViTClassifier(num_classes=num_classes).to(self.device)
+        self.model = ViTClassifier(num_classes=num_classes, weights=weights).to(self.device)
 
     def predict(self, x: torch.Tensor, return_probs: bool = False):
         self.model.eval()

--- a/models/vit.py
+++ b/models/vit.py
@@ -2,9 +2,9 @@ import torch.nn as nn
 from torchvision.models import vit_b_16, ViT_B_16_Weights
 
 class ViTClassifier(nn.Module):
-    def __init__(self, num_classes):
+    def __init__(self, num_classes, weights=None):
         super().__init__()
-        self.base = vit_b_16(weights=ViT_B_16_Weights.DEFAULT)
+        self.base = vit_b_16(weights=weights)
         self.base.heads[0] = nn.Linear(self.base.heads[0].in_features, num_classes)
 
     def forward(self, x):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 python-multipart
+numpy<2
 pillow
 pyyaml
 torch==2.2.2+cpu

--- a/scripts/mri/inference.py
+++ b/scripts/mri/inference.py
@@ -26,7 +26,8 @@ def predict(image_input, config_path="configs/mri/config.yaml"):
     
     model_wrapper = AlzheimerMRIModel(
         num_classes=config["model"]["num_classes"],
-        device=device
+        device=device,
+        weights=None
     )
     model_path = os.path.join(config["paths"]["model_dir"], config["paths"]["model_file"])
     model_wrapper.load_weights(model_path)

--- a/scripts/mri/train.py
+++ b/scripts/mri/train.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import torch
 from torch import nn, optim
 from torch.utils.data import DataLoader, Subset
+from torchvision.models import ViT_B_16_Weights
 from domains.mri.dataset import MRIClassifierDataset
 from domains.mri.model import AlzheimerMRIModel
 from training.trainer import Trainer
@@ -28,7 +29,8 @@ if __name__ == "__main__":
     # Setup
     model_wrapper = AlzheimerMRIModel(
         num_classes=config["model"]["num_classes"],
-        device=device
+        device=device,
+        weights=ViT_B_16_Weights.DEFAULT
     )
     model = model_wrapper.get_model()
 


### PR DESCRIPTION
This PR includes two key updates:

1. Inference weight handling fix

- Updated the ViTClassifier and AlzheimerMRIModel classes to accept an optional weights argument.
- Ensured that inference sets weights=None to avoid unintentionally loading pretrained ViT_B_16 weights.
- This ensures only the custom trained weights from the load_weights() call are used.

2. PyTorch compatibility fix

- Pinned NumPy version to <2 in requirements.txt to avoid runtime incompatibilities with CPU-based PyTorch/torchvision compiled against NumPy 1.x.

These changes improve clarity, correctness, and stability during both training and deployment of the model.