### PR TITLE
Add debug logs for model loading and prediction

### DIFF
--- a/app/routes/mri/predict.py
+++ b/app/routes/mri/predict.py
@@ -8,8 +8,11 @@ CLASSES = ["Mild Demented", "Moderate Demented", "Non Demented", "Very Mild Deme
 
 @router.post("/mri/predict")
 async def mri_predict(file: UploadFile = File(...)):
+    print("[DEBUG] /mri/predict endpoint hit.")
     image_bytes = await file.read()
+    print("[DEBUG] File received, size:", len(image_bytes))
     predicted_class, probs = predict(image_bytes)
+    print("[DEBUG] Returning prediction response.")
 
     return JSONResponse(content={
         "prediction": CLASSES[predicted_class],

--- a/scripts/mri/inference.py
+++ b/scripts/mri/inference.py
@@ -21,20 +21,27 @@ def load_image(image_input, device):
     return image.to(device)
 
 def predict(image_input, config_path="configs/mri/config.yaml"):
+    print("[DEBUG] Loading config...")
     config = load_config(config_path)
     device = config["device"]
+    print(f"[DEBUG] Device set to: {device}")
     
+    print("[DEBUG] Initializing AlzheimerMRIModel...")
     model_wrapper = AlzheimerMRIModel(
         num_classes=config["model"]["num_classes"],
         device=device,
         weights=None
     )
     model_path = os.path.join(config["paths"]["model_dir"], config["paths"]["model_file"])
+    print(f"[DEBUG] Loading model weights from: {model_path}")
     model_wrapper.load_weights(model_path)
+    print("[DEBUG] Model weights loaded.")
 
+    print("[DEBUG] Preprocessing image...")
     image_tensor = load_image(image_input, device)
     probs = model_wrapper.predict(image_tensor, return_probs=True).cpu().numpy()[0]
     predicted_class = int(probs.argmax())
+    print(f"[DEBUG] Prediction complete. Predicted class: {predicted_class}")
     return predicted_class, probs.tolist()
 
 # Example


### PR DESCRIPTION
This PR introduces debug print() statements throughout the MRI inference pipeline to assist in identifying runtime bottlenecks or silent failures during container execution.