### PR TITLE
Add CORS middleware to enable /mri/predict from Swagger UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,17 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from app.routes.mri import predict  # Import your router
 
 app = FastAPI()
+
+# Enable CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Use specific domains in production
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Include the MRI prediction route
 app.include_router(predict.router)


### PR DESCRIPTION
Enables CORS to fix failed Swagger POST requests on deployed app