### PR TITLE
Add MobileNetV2 model support for MRI classification and refactor acc…

### DIFF
--- a/configs/mri/config.yaml
+++ b/configs/mri/config.yaml
@@ -1,5 +1,5 @@
 model:
-  name: vit
+  name: mobilenetv2 # vit
   num_classes: 4
 
 dataset:
@@ -19,6 +19,6 @@ paths:
   model_dir: outputs/models/mri
   log_dir: outputs/logs/mri
   eval_dir: outputs/eval/mri
-  model_file: vit_mri.pth
+  model_file: mobilenetv2_mri_20250721_200204.pth # vit_mri.pth
 
 device: cpu

--- a/domains/mri/model.py
+++ b/domains/mri/model.py
@@ -2,11 +2,18 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 from models.vit import ViTClassifier
+from models.mobilenet import MobileNetV2MRI
 
 class AlzheimerMRIModel:
-    def __init__(self, num_classes=None, device=None, weights=None):
+    def __init__(self, num_classes=None, device=None, weights=None, architecture="mobilenetv2"):
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
-        self.model = ViTClassifier(num_classes=num_classes, weights=weights).to(self.device)
+
+        if architecture == "vit":
+            self.model = ViTClassifier(num_classes=num_classes, weights=weights)
+        elif architecture == "mobilenetv2":
+            self.model = MobileNetV2MRI(num_classes=num_classes, weights=weights)
+        else:
+            raise ValueError(f"Unsupported architecture: {architecture}")
 
     def predict(self, x: torch.Tensor, return_probs: bool = False):
         self.model.eval()

--- a/models/mobilenet.py
+++ b/models/mobilenet.py
@@ -1,0 +1,11 @@
+import torch.nn as nn
+from torchvision.models import mobilenet_v2
+
+class MobileNetV2MRI(nn.Module):
+    def __init__(self, num_classes, weights=None):
+        super().__init__()
+        self.model = mobilenet_v2(weights=weights)
+        self.model.classifier[1] = nn.Linear(self.model.last_channel, num_classes)
+
+    def forward(self, x):
+        return self.model(x)

--- a/models/vit.py
+++ b/models/vit.py
@@ -1,5 +1,5 @@
 import torch.nn as nn
-from torchvision.models import vit_b_16, ViT_B_16_Weights
+from torchvision.models import vit_b_16
 
 class ViTClassifier(nn.Module):
     def __init__(self, num_classes, weights=None):

--- a/scripts/mri/inference.py
+++ b/scripts/mri/inference.py
@@ -31,7 +31,8 @@ def predict(image_input, config_path="configs/mri/config.yaml"):
         model_wrapper = AlzheimerMRIModel(
             num_classes=config["model"]["num_classes"],
             device=device,
-            weights=None
+            weights=None,
+            architecture=config["model"]["name"]
         )
         model_path = os.path.join(config["paths"]["model_dir"], config["paths"]["model_file"])
         print(f"[DEBUG] Loading model weights from: {model_path}")


### PR DESCRIPTION
### Changes:
- Added `mobilenet.py` model class (lightweight CNN for EC2)
- Refactored `AlzheimerMRIModel` to support both ViT and MobileNetV2
- Updated training (`train.py`) to dynamically select architecture from config
- Modified inference to work with either model based on config
- Adjusted `config.yaml` to use MobileNetV2 with 4-class MRI classification
- Model trained and tested locally on sample dataset; inference confirmed working

### Notes:
- ViT model preserved for flexibility
- MobileNetV2 model is ~9MB and optimized for EC2 deployment